### PR TITLE
Add google sheet logging and other features

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -10,6 +10,7 @@ type = RNG_CTRL
 enable_polling = false
 poll_interval = 60
 # poll_interval => read data interval (seconds)
+temperature_unit = F # F = Fahrenheit, blank or anything else = Celsius
 
 [remote_logging]
 enabled = false

--- a/config.ini
+++ b/config.ini
@@ -22,11 +22,17 @@ enabled = false
 server = 192.168.0.16
 port = 1883
 topic = solar/stats
-user = 
-password = 
+user =
+password =
 
 [pvoutput]
 # free accounts has a cap of max one request per minute.
 enabled = false
 api_key =
 system_id =
+
+[google_sheets]
+enabled = false
+sheet_id =
+worksheet_name =
+credentials_file = service_account.json

--- a/config.ini
+++ b/config.ini
@@ -11,6 +11,7 @@ enable_polling = false
 poll_interval = 60
 # poll_interval => read data interval (seconds)
 temperature_unit = F # F = Fahrenheit, blank or anything else = Celsius
+fields = battery_percentage, battery_voltage, battery_current, controller_temperature, load_status, load_voltage, load_current, load_power, pv_voltage, pv_current, pv_power, max_charging_power_today, max_discharging_power_today, charging_amp_hours_today, discharging_amp_hours_today, power_generation_today, power_consumption_today, power_generation_total, charging_status
 
 [remote_logging]
 enabled = false

--- a/example.py
+++ b/example.py
@@ -2,7 +2,8 @@ import logging
 import configparser
 import os
 import sys
-from renogybt import RoverClient, RoverHistoryClient, BatteryClient, DataLogger
+from renogybt import RoverClient, RoverHistoryClient, BatteryClient, DataLogger, Utils
+from renogybt.Utils import filter_fields
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -14,24 +15,25 @@ data_logger: DataLogger = DataLogger(config)
 
 # the callback func when you receive data
 def on_data_received(client, data):
-    logging.debug("{} => {}".format(client.device.alias(), data))
+    filtered_data = filter_fields(data, config['device']['fields'])
+    logging.debug("{} => {}".format(client.device.alias(), filtered_data))
     if config['remote_logging'].getboolean('enabled'):
-        data_logger.log_remote(json_data=data)
+        data_logger.log_remote(json_data=filtered_data)
     if config['google_sheets'].getboolean('enabled'):
-        data_logger.log_google_sheets(json_data=data)
+        data_logger.log_google_sheets(json_data=filtered_data)
     if config['mqtt'].getboolean('enabled'):
-        data_logger.log_mqtt(json_data=data)
+        data_logger.log_mqtt(json_data=filtered_data)
     if config['pvoutput'].getboolean('enabled') and config['device']['type'] == 'RNG_CTRL':
-        data_logger.log_pvoutput(json_data=data)
+        data_logger.log_pvoutput(json_data=filtered_data)
     if not config['device'].getboolean('enable_polling'):
         client.disconnect()
 
 # start client
 if config['device']['type'] == 'RNG_CTRL':
-    RoverClient(config, on_data_received).connect() 
+    RoverClient(config, on_data_received).connect()
 elif config['device']['type'] == 'RNG_CTRL_HIST':
-    RoverHistoryClient(config, on_data_received).connect() 
+    RoverHistoryClient(config, on_data_received).connect()
 elif config['device']['type'] == 'RNG_BATT':
     BatteryClient(config, on_data_received).connect()
-else: 
+else:
     logging.error("unknown device type")

--- a/example.py
+++ b/example.py
@@ -17,6 +17,8 @@ def on_data_received(client, data):
     logging.debug("{} => {}".format(client.device.alias(), data))
     if config['remote_logging'].getboolean('enabled'):
         data_logger.log_remote(json_data=data)
+    if config['google_sheets'].getboolean('enabled'):
+        data_logger.log_google_sheets(json_data=data)
     if config['mqtt'].getboolean('enabled'):
         data_logger.log_mqtt(json_data=data)
     if config['pvoutput'].getboolean('enabled') and config['device']['type'] == 'RNG_CTRL':

--- a/renogybt/DataLogger.py
+++ b/renogybt/DataLogger.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import requests
+import gspread
 import paho.mqtt.publish as publish
 from configparser import ConfigParser
 from datetime import datetime
@@ -38,3 +39,22 @@ class DataLogger:
             "X-Pvoutput-SystemId":  self.config['pvoutput']['system_id']
         })
         print(f"pvoutput {response}")
+
+    def is_first_row_empty(worksheet):
+        return len(worksheet.row_values(1)) == 0
+
+    def log_google_sheets(self, json_data):
+        now = datetime.now()
+        dt_string = now.strftime("%m/%d/%Y %H:%M:%S")
+        sheet_id = self.config['google_sheets']['sheet_id']
+        worksheet_name = self.config['google_sheets']['worksheet_name']
+        credentials_file = self.config['google_sheets']['credentials_file']
+        sa = gspread.service_account(filename=credentials_file)
+        sh = sa.open_by_key(sheet_id)
+        wks = sh.worksheet(worksheet_name)
+        output = json_data
+        values = [dt_string] + list(output.values())
+        if DataLogger.is_first_row_empty(wks):
+          keys = ["Date/Time"] + list(output.keys())
+          wks.append_row(keys)
+        wks.append_row(values)

--- a/renogybt/RoverClient.py
+++ b/renogybt/RoverClient.py
@@ -1,6 +1,6 @@
 import logging
 from .BaseClient import BaseClient
-from .Utils import bytes_to_int, parse_temperature
+from .Utils import bytes_to_int, parse_temperature, celcius_to_farhenheit
 
 # Read and parse BT-1 RS232 type bluetooth module connected to Renogy Rover/Wanderer/Adventurer
 # series charge controllers. Also works with BT-2 RS485 module on Rover Elite, DC Charger etc.
@@ -80,8 +80,8 @@ class RoverClient(BaseClient):
         data['battery_percentage'] = bytes_to_int(bs, 3, 2)
         data['battery_voltage'] = bytes_to_int(bs, 5, 2) * 0.1
         data['battery_current'] = bytes_to_int(bs, 7, 2) * 0.01
-        data['battery_temperature'] = parse_temperature(bytes_to_int(bs, 10, 1))
-        data['controller_temperature'] = parse_temperature(bytes_to_int(bs, 9, 1))
+        data['battery_temperature'] = self.parse_temperature(bytes_to_int(bs, 10, 1))
+        data['controller_temperature'] = self.parse_temperature(bytes_to_int(bs, 9, 1))
         data['load_status'] = LOAD_STATE.get(bytes_to_int(bs, 67, 1) >> 7)
         data['load_voltage'] = bytes_to_int(bs, 11, 2) * 0.1
         data['load_current'] = bytes_to_int(bs, 13, 2) * 0.01
@@ -110,3 +110,10 @@ class RoverClient(BaseClient):
         data['function'] = FUNCTION.get(bytes_to_int(bs, 1, 1))
         data['load_status'] = bytes_to_int(bs, 5, 1)
         self.data.update(data)
+
+    def parse_temperature(self, value):
+        temperature = parse_temperature(value)
+        temperature_unit = self.config['device']['temperature_unit']
+        if temperature_unit == 'F':
+            return celcius_to_farhenheit(temperature)
+        return temperature

--- a/renogybt/Utils.py
+++ b/renogybt/Utils.py
@@ -76,3 +76,6 @@ def crc16_modbus(data: bytes):
         crc_low = CRC16_LOW_BYTES[index]
 
     return bytes([crc_high, crc_low])
+
+def celcius_to_farhenheit(celcius):
+    return (celcius * 9/5) + 32

--- a/renogybt/Utils.py
+++ b/renogybt/Utils.py
@@ -79,3 +79,9 @@ def crc16_modbus(data: bytes):
 
 def celcius_to_farhenheit(celcius):
     return (celcius * 9/5) + 32
+
+def filter_fields(data, fields_str):
+    fields = [x.strip() for x in fields_str.split(',')] if len(fields_str) > 0 else [] # trim spaces
+    if len(fields) > 0 and set(fields).issubset(data):
+        return {key: data[key] for key in fields}
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 gatt
 paho-mqtt
+gspread


### PR DESCRIPTION
This adds the ability to log to Google Sheets. It uses the [gspread library](https://github.com/burnash/gspread), which is a Python wrapper around the Google sheet API. The library explains the process of creating a credential file needed to use it.

Additionally, it adds a config option to display temperatures in Fahrenheit, and another config option to log a specified set of fields, rather than all of them.