### PR TITLE
Fix TypeError from missing import.

### DIFF
--- a/renogybt/__init__.py
+++ b/renogybt/__init__.py
@@ -2,4 +2,5 @@ from .RoverClient import RoverClient
 from .DataLogger import DataLogger
 from .BatteryClient import BatteryClient
 from .RoverHistoryClient import RoverHistoryClient
+from .InverterClient import InverterClient
 from .Utils import *


### PR DESCRIPTION

Imports InverterClient in `renogybt/__init__.py` to avoid a TypeError.
```
$ python3 ./example.py config.ini
Traceback (most recent call last):
  File ".../renogy-bt/example.py", line 37, in <module>
    InverterClient(config, on_data_received).connect()
TypeError: 'module' object is not callable
```